### PR TITLE
Fix connections being reuse

### DIFF
--- a/hfdownloader/hfdownloader.go
+++ b/hfdownloader/hfdownloader.go
@@ -431,7 +431,9 @@ func downloadChunk(tempFolder string, outputFileName string, idx int, url string
 		progress <- int64(math.Max(float64(fi.Size()-compensationBytes), 0.0))
 	}
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{},
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
The current implementation in linux is not transporting with multiple connections. We can use cmd `netstat` to confirm.
Assigning a new transport will prevent from reusing the same connection.