### PR TITLE
Handle .gguf{,-split-{a,b,....}} files

### DIFF
--- a/hfdownloader/hfdownloader.go
+++ b/hfdownloader/hfdownloader.go
@@ -222,6 +222,7 @@ func processHFFolderTree(ModelPath string, IsDataset bool, SkipSHA bool, ModelDa
 			if HasFilter {
 				filenameLowerCase := strings.ToLower(jsonFilesList[i].Path)
 				if strings.HasSuffix(filenameLowerCase, ".act") || strings.HasSuffix(filenameLowerCase, ".bin") ||
+					strings.Contains(filenameLowerCase, ".gguf") || // either *.gguf or *.gguf-split-{a, b, ...}
 					strings.HasSuffix(filenameLowerCase, ".safetensors") || strings.HasSuffix(filenameLowerCase, ".pt") || strings.HasSuffix(filenameLowerCase, ".meta") ||
 					strings.HasSuffix(filenameLowerCase, ".zip") || strings.HasSuffix(filenameLowerCase, ".z01") || strings.HasSuffix(filenameLowerCase, ".onnx") || strings.HasSuffix(filenameLowerCase, ".data") ||
 					strings.HasSuffix(filenameLowerCase, ".onnx_data") {


### PR DESCRIPTION
Add .gguf (and .gguf-split-a, .gguf-split-b etc.) to the whitelist.

Note: I find it unclear why there is a whitelist for the filenames. Wouldn't it be acceptable to just match the filter to every file instead of specifically allowing certain filename suffixes?