### PR TITLE
- Use /usr/bin/env to find bash, making build scripts compatiable with NixOS and other non-standard systems.

### DIFF
--- a/BuildAll.sh
+++ b/BuildAll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm output/*
 # Build script for all platforms
 

--- a/BuildArmArm64.sh
+++ b/BuildArmArm64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 output_dir="output"
 binaryName="hfdownloader"

--- a/BuildDarwinAmd64.sh
+++ b/BuildDarwinAmd64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 output_dir="output"
 binaryName="hfdownloader"

--- a/BuildDarwinArm64.sh
+++ b/BuildDarwinArm64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 output_dir="output"
 binaryName="hfdownloader"

--- a/BuildLinuxAmd64.sh
+++ b/BuildLinuxAmd64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 output_dir="output"
 binaryName="hfdownloader"

--- a/BuildWindowsAmd64.sh
+++ b/BuildWindowsAmd64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 output_dir="output"
 binaryName="hfdownloader"


### PR DESCRIPTION
Bash is usually but not always found at /bin/bash (on NixOS it's at /run/current-system/sw/bin/bash, others systems might install in /usr/bin/bash), when bash is in the path it's a best practice to locate it using env.  These changes do that.