### PR TITLE
Fix Hugging Face API 400s with updated Hub behavior

### DIFF
--- a/hfdownloader/types.go
+++ b/hfdownloader/types.go
@@ -19,6 +19,8 @@ type Settings struct {
 	BackoffInitial     string
 	BackoffMax         string
 	Token              string
+	// Verbose enables additional debug logging (e.g. HTTP calls) when true.
+	Verbose            bool
 }
 
 type ProgressEvent struct {

--- a/main.go
+++ b/main.go
@@ -178,6 +178,8 @@ func finalize(cmd *cobra.Command, ro *rootOpts, args []string, job *hfdownloader
 	if !hfdownloader.IsValidModelName(j.Repo) {
 		return j, c, fmt.Errorf("invalid repo id %q (expected owner/name)", j.Repo)
 	}
+	// propagate verbose flag into settings so the library can emit debug logs
+	c.Verbose = ro.verbose
 	return j, c, nil
 }
 


### PR DESCRIPTION
This PR fixes #56 
 400 Bad Request errors from the Hugging Face Hub by no longer URL-encoding the repo id (owner/name) in tree, raw, and resolve URLs. It also adds minimal verbose tree logging and enriches tree API error messages (including X-Error-Message and X-Request-Id), and has been tested against unsloth/MiniMax-M2-GGUF:UD-Q4_K_XL with successful downloads.

Key changes:
- Use raw owner/name in repo path segments for tree/raw/resolve endpoints (avoid %2F).
- Add verbose tree request logging when -v is set.
- Surface detailed Hub error information when tree requests fail.