### PR TITLE
Assume LFS OID is SHA256 value if SHA256 field missing from LFS Info.

### DIFF
--- a/pkg/hfdownloader/plan.go
+++ b/pkg/hfdownloader/plan.go
@@ -117,6 +117,11 @@ func scanRepo(ctx context.Context, httpc *http.Client, token string, job Job, cf
 			sha = n.LFS.Sha256
 		}
 
+		// if sha not loaded from HF json repo API use the LFS file OID instead (the HF API does not contain the SHA256 hash, so this is alway true for LFS files)
+		if sha == "" && n.LFS != nil {
+			sha = n.LFS.Oid
+		}
+
 		items = append(items, PlanItem{
 			RelativePath: rel,
 			URL:          urlStr,


### PR DESCRIPTION
This fix allows models that have been updated in their repo to be detected as hash mismatch and re-downloaded.

The Hugging face api does not have a field 'SHA' or 'SHA256' on LFS files. The LFS oid is the SHA256 hash of the file so use that when the LFS SHA256 is missing, which it always will be. 
Api example: https://huggingface.co/api/models/Qwen/Qwen3-0.6B/tree/main